### PR TITLE
New proc: ProtocolConverter

### DIFF
--- a/eslib/procs/ProtocolConverter.py
+++ b/eslib/procs/ProtocolConverter.py
@@ -1,0 +1,22 @@
+__author__ = 'Hans Terje Bakke'
+
+from ..Processor import Processor
+
+class ProtocolConverter(Processor):
+
+    def __init__(self, func, input_protocol=None, output_protocol=None, **kwargs):
+        super(ProtocolConverter, self).__init__(**kwargs)
+        self.create_connector(self._incoming, "input", input_protocol)
+        self._output = self.create_socket("output", output_protocol)
+
+        self._func = func
+
+    def _incoming(self, incoming):
+
+        try:
+            outgoing = self._func(incoming)
+        except Exception as e:
+            self.doclog.exception("Error in protocol converter function call.")
+
+        if outgoing:
+            self._output.send(outgoing)

--- a/eslib/procs/__init__.py
+++ b/eslib/procs/__init__.py
@@ -30,6 +30,7 @@ from .HtmlRemover           import HtmlRemover
 from .BlacklistFilter       import BlacklistFilter
 from .Throttle              import Throttle
 from .ParseEdgeToIds        import ParseEdgeToIds
+from .ProtocolConverter     import ProtocolConverter
 
 
 __all__ = (
@@ -54,5 +55,6 @@ __all__ = (
     "PatternRemover",
     "HtmlRemover",
     "BlacklistFilter",
-    "Throttle"
+    "Throttle",
+    "ProtocolConverter"
 )

--- a/examples/pipeline.py
+++ b/examples/pipeline.py
@@ -29,7 +29,7 @@ p.subscribe(r)
 
 
 w.subscribe(p)
-w.config.domains = [{"domain_id": "http://localhost", "url_prefix":"http://localhost"}]
+w.config.domains = [{"domain_id": "localhost", "url_prefix":"http://localhost"}]
 w.add_callback(listener, socket_name="output")
 r.start()
 

--- a/test/procs/protocol_converter.py
+++ b/test/procs/protocol_converter.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+
+import unittest
+from eslib.procs import ProtocolConverter
+
+import logging
+LOG_FORMAT = ('%(levelname) -10s %(name) -55s %(funcName) -30s %(lineno) -5d: %(message)s')
+#logging.basicConfig(level=logging.DEBUG, format=LOG_FORMAT)
+
+class TestProtocolConverter(unittest.TestCase):
+
+    def test_func(self):
+
+        csv2list = lambda doc: ",".join(doc)
+
+        p = ProtocolConverter(csv2list, input_protocol="list", output_protocol="csv")
+        p.keepalive = True
+
+        output = []
+        p.add_callback(lambda doc: output.append(doc))
+
+        p.start()
+        p.put(["a","b","c","d"])
+        p.stop()
+        p.wait()
+
+        print "output=", output[0]
+
+        self.assertEqual(output[0], "a,b,c,d")
+
+def main():
+    unittest.main()
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
For those tiny tasks where writing a new proc seems overkill and messes up the lib.
Example usage for converting list to comma separated string:

```
    csv2list = lambda doc: ",".join(doc)
    p = ProtocolConverter(func=csv2list, input_protocol="list", output_protocol="csv")
```
