### PR TITLE
Parent/child support in Elasticsearch Reader/Writer

### DIFF
--- a/eslib/procs/ElasticsearchWriter.py
+++ b/eslib/procs/ElasticsearchWriter.py
@@ -86,7 +86,7 @@ class ElasticsearchWriter(Generator):
             meta = {"_index": index, "_type": doctype}
             parent = document.get("_parent")
             if parent:
-                meta["parent"] = parent  # Yes, it is actually without underscore. The doc._parent is an eslib construct.
+                meta["_parent"] = parent
 
             if self.config.update_fields:
                 # Use the partial 'update' API


### PR DESCRIPTION
Support for parent reference reading and writing via doc._parent field.